### PR TITLE
Update docs to install a known good version of cargo-n64

### DIFF
--- a/examples/03-booting-rust/README.md
+++ b/examples/03-booting-rust/README.md
@@ -15,9 +15,11 @@ This example is pure Rust, so there are no SDK dependencies. It does, however, r
 * [cargo-n64](https://github.com/rust-console/cargo-n64) - A `cargo` subcommand to build Nintendo 64 ROMs in Rust
 * [N64 IPL3](https://retrocomputing.stackexchange.com/questions/14189/what-is-the-nintendo-64-ipl3-and-how-could-it-be-created-by-rust-developers) - boot code for the N64
 
-You can install `cargo-n64` from crates.io:
+You can install `cargo-n64` using cargo install:
 
-    cargo install cargo-n64
+    cargo +nightly-2022-06-21 install --git https://github.com/rust-console/cargo-n64/ --rev 98f23023dcd2eae21484179309f58eb7ddd5bfd5
+
+NOTE: crates.io has an old version of `cargo-n64` which uses an old toolchain (nightly-2021-08-07). The command above installs a known working version from git.
 
 The N64 IPL3 binary can be found in the SDK, or extracted from a ROM.
 

--- a/examples/04-graphics-in-rust/README.md
+++ b/examples/04-graphics-in-rust/README.md
@@ -18,7 +18,7 @@ These required some minor modifications to compile, which are included here in [
 Install cargo-n64:
 
 ```
-cargo install cargo-n64
+cargo +nightly-2022-06-21 install --git https://github.com/rust-console/cargo-n64/ --rev 98f23023dcd2eae21484179309f58eb7ddd5bfd5
 ```
 
 Install rs64-romtool (used to update checksum at the end):


### PR DESCRIPTION
Hi! Thanks for the talk at Rust Melbourne! 

I tried building the third example, however received the following error:

```
[jbit@Aya]~/dev/n64-heart-rust/examples/03-booting-rust$ make
Building target/mips-nintendo64-none/release/booting-rust.n64...
    Building with cargo build-std
error: toolchain 'nightly-2021-08-07-x86_64-unknown-linux-gnu' is not installed
error: Build error
caused by: Subcommand failed
caused by: Command failed with exit code: Some(1)
make: *** [GNUmakefile:11: target/mips-nintendo64-none/release/booting-rust.n64] Error 1
```

This is because the version of `cargo-n64` installed by `cargo install cargo-n64` expects the `nightly-2021-08-07` toolchain, and this project uses `nightly-2022-06-21`.

Unfortunately the updated version of `cargo-n64` which uses `nightly-2022-06-21` has not been published to crates.io.

This pull request simply updates the README.md file with a command to install the latest version of `cargo-n64` from git using a known working toolchain.